### PR TITLE
Update vi mode docs to reflect actual behavior

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -987,6 +987,8 @@ Some bindings are shared between emacs- and vi-mode because they aren't text edi
 
 - @key{Control,W} moves the previous path component (everything up to the previous "/") to the <a href="#killring">killring</a>.
 
+- @key{Control,X} copies the current buffer to the system's clipboard, @key{Control,V} inserts the clipboard contents.
+
 - @key{Alt,D} moves the next word to the <a href="#killring">killring</a>.
 
 - @key{Alt,H} (or @key{F1}) shows the manual page for the current command, if one exists.
@@ -1068,16 +1070,15 @@ Command mode is also known as normal mode.
 
 - @key{[} and @key{]} search the command history for the previous/next token containing the token under the cursor before the search was started. See the <a href='#history'>history</a> section for more information on history searching.
 
-- @key{Control, X} copies the current buffer to the system's clipboard, @key{Control, V} inserts the clipboard contents.
 - @key{Control,C} deletes the entire line.
 
 - @key{Backspace} moves the cursor left.
 
 \subsubsection vi-mode-insert Insert mode
 
-- @key{Escape} or @key{Control,C} enters <a href="#vi-mode-command">command mode</a>.
+- @key{Escape} enters <a href="#vi-mode-command">command mode</a>.
 
-- @key{Control,x} moves the cursor to the end of the line. If an autosuggestion is available, it will be accepted completely.
+- @key{Control,C} deletes the entire line.
 
 - @key{Backspace} removes one character to the left.
 


### PR DESCRIPTION
## Description

It seems fish vi bindings were updated in fish 2.4.0 but in some cases the documentation does not correctly reflect the actual behavior.

I've updated the docs to reflect the actual behavior. Although maybe the docs were the intended behavior and the bindings should be fixed instead?

/cc @faho @krader1961